### PR TITLE
Update build.gradle to use latest Stitch SDKs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'org.mongodb:stitch-android-sdk:4.0.0'
-    implementation 'org.mongodb:stitch-android-services-mongodb-local:4.0.0'
+    implementation 'org.mongodb:stitch-android-sdk:4.0.3'
+    implementation 'org.mongodb:stitch-android-services-mongodb-local:4.0.3'
 }


### PR DESCRIPTION
It was using the old 4.0.0 stitch SDKs which bundled the old [embedded Java driver](https://github.com/mongodb/mongo-java-driver/tree/embedded) which in turn used the old MongoDB embedded SDK ABI. The end result is runtime errors during app load like this:
`com.mongodb.embedded.client.MongoClientEmbeddedException: Error from embedded server when calling 'status_create': Error looking up function 'libmongodbcapi_status_create': undefined symbol: libmongodbcapi_status_create`

This is because the Embedded C ABI symbols were versioned and renamed about 7 weeks ago via [this patch](https://github.com/mongodb/mongo/commit/424dc423aff51129ef64ff109c7288330570fa28).

I've updated the build file to use the [latest Stitch SDKs](https://github.com/mongodb/stitch-android-sdk/blob/master/README.md#installation) as of today -- 4.0.3 -- which resolves the issues as it bundles the latest embedded Java driver which is in turn using the latest MongoDB embedded SDK ABI.